### PR TITLE
Only send 1st frame of animated GIFs

### DIFF
--- a/preview
+++ b/preview
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 image() {
-   chafa "$1" -f sixel -s "$(($2-2))x$3" | sed 's/#/\n#/g'
+	geometry="$(($2-2))x$3"
+	chafa "$1" -f sixel -s "$geometry" --animate false | fold -w 65535
 }
 
 batorcat() {


### PR DESCRIPTION
When previewing animated GIFs, only send sixel for the first frame to the previewer.